### PR TITLE
Add `repoType` option to select what type of repos to pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Options:
   --filter, -f          Comma separated list of repos to ignore.                                     
   --help, -h            Usage docs.
   --host,               GitHub host or export GITHUB_HOST env variable.                                  [default: "api.github.com"]
+  --repoType            Repo type: all, public, private, forks, sources, member (public is default)
   --norc                Disable parsing of the ~./orgcommitsrc config.
   --pathPrefix, --path  Path prefix for GitHub API requests. Typically used for GitHub Enterprise users.
   --pulls, -p           Displays pull request commits only, grouped by labels (if applicable).

--- a/lib/options.js
+++ b/lib/options.js
@@ -41,6 +41,10 @@ module.exports = {
         alias: 'r',
         describe: 'Specify a repository to query.'
     },
+    repoType: {
+      describe: 'Repo type to pull: all, public, private, forks, sources, member',
+      'default': 'public'
+    },
     sha: {
         alias: 's',
         describe: 'Git sha or branch to pull data from (e.g. master, gh-pages, etc).',

--- a/lib/org-commits.js
+++ b/lib/org-commits.js
@@ -27,6 +27,7 @@ export class OrgCommits {
         this.pathPrefix = options.pathPrefix;
         this.repo = options.repo;
         this.org = options.org;
+        this.repoType = options.repoType;
 
         this.repoFilter = options.filter ? options.filter.split(',') : undefined;
 
@@ -94,7 +95,7 @@ export class OrgCommits {
             });
         } else if (this.org) {
             // otherwise collect repo's across the org
-            return this.getFromOrg(this.org).then(() => {
+            return this.getFromOrg(this.org, this.repoType).then(() => {
                 this.displayOutput();
                 return this.output;
             });
@@ -124,13 +125,13 @@ export class OrgCommits {
     }
 
     // get all repo's from organization
-    getFromOrg(org) {
+    getFromOrg(org, type) {
         debug('get from org');
         return new Promise((resolve, reject) => {
             // grab repos for the org
             this.github.repos.getForOrg({
                 org: org,
-                type: 'public',
+                type: type,
                 per_page: 100
             }, (err, results) => {
                 if (err || !results) {


### PR DESCRIPTION
Thanks for creating this package! The repo type was hardcoded to `public` and I needed to pull from private repos of an organization, so I've added the `repoType` option.